### PR TITLE
feat: 新增配置类WebClientConfig,强制使用 HTTP/1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>
         </dependency>
-
+		
+		<!-- HttpClient -->
+		<dependency>
+			<groupId>io.projectreactor.netty</groupId>
+			<artifactId>reactor-netty-http</artifactId>
+		</dependency>
+		
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/alibaba/cloud/ai/copilot/config/WebClientConfig.java
+++ b/src/main/java/com/alibaba/cloud/ai/copilot/config/WebClientConfig.java
@@ -1,0 +1,26 @@
+package com.alibaba.cloud.ai.copilot.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.HttpProtocol;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+
+/**
+ * 目的: 强制使用 HTTP/1.1
+ */
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        // 创建并直接配置 HttpClient
+        HttpClient httpClient = HttpClient.create()
+            .protocol(HttpProtocol.HTTP11);  // 强制使用 HTTP/1.1
+
+        return WebClient.builder()
+            .clientConnector(new ReactorClientHttpConnector(httpClient)) // 集成配置
+            .build();
+    }
+}


### PR DESCRIPTION
解决vllm启动的模型-不支持HTTP2-导致400报错