### PR TITLE
feat(bug): Title: Setting max_tokens to 100,000 exceeds DeepSeek API limits!

### DIFF
--- a/scripts/sql/init_model_config.sql
+++ b/scripts/sql/init_model_config.sql
@@ -26,5 +26,5 @@ CREATE TABLE IF NOT EXISTS model_config (
 
 -- 插入初始数据
 INSERT INTO model_config (model_name, model_key, use_image, description, icon_url, provider, api_key, api_url, function_call, enabled, sort_order) VALUES
-('deepseek-R1', 'deepseek-reasoner', 0, 'Deepseek R1 model with reasoning and chain-of-thought capabilities', NULL, 'deepseek', NULL, NULL, 0, 1, 3),
-('deepseek-v3', 'deepseek-chat', 0, 'Deepseek V3 model', NULL, 'deepseek', NULL, NULL, 1, 1, 4)
+('deepseek-reasoner', 'deepseek-reasoner', 0, 'Deepseek R1 model with reasoning and chain-of-thought capabilities', NULL, 'deepseek', NULL, NULL, 0, 1, 3),
+('deepseek-chat', 'deepseek-chat', 0, 'Deepseek V3 model', NULL, 'deepseek', NULL, NULL, 1, 1, 4)


### PR DESCRIPTION
DeepSeek's max_tokens limit is typically 4096 or 8192. Sending 100000 will result in a 400 Bad Request.  Optimize the createDefaultChatOptions method to intelligently select appropriate token limits based on different models.